### PR TITLE
fix: remove discord secret

### DIFF
--- a/docs/guides/ecosystem/discordjs.md
+++ b/docs/guides/ecosystem/discordjs.md
@@ -26,14 +26,6 @@ Before we go further, we need to go to the [Discord developer portal](https://di
 
 Once complete, you'll be presented with your bot's _private key_. Let's add this to a file called `.env.local`. Bun automatically reads this file and loads it into `process.env`.
 
-{% callout %}
-This is an example token that has already been invalidated.
-{% /callout %}
-
-```txt#.env.local
-DISCORD_TOKEN=NzkyNzE1NDU0MTk2MDg4ODQy.X-hvzA.Ovy4MCQywSkoMRRclStW4xAYK7I
-```
-
 ---
 
 Be sure to add `.env.local` to your `.gitignore`! It is dangerous to check your bot's private key into version control.


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

This removes the invalidated discord token from the guides.


- [X] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

It's a documentation change.

### Why?

The developers won't see the below error when they push to a bun project.

```bash
remote: Resolving deltas: 100% (144/144), done.
remote: error: GH013: Repository rule violations found for refs/heads/feat/add-load-tests.
remote: 
remote: - GITHUB PUSH PROTECTION
remote:   —————————————————————————————————————————
remote:     Resolve the following violations before pushing again
remote: 
remote:     - Push cannot contain secrets
remote: 
remote:     
remote:      (?) Learn how to resolve a blocked push
remote:      https://docs.github.com/code-security/secret-scanning/working-with-secret-scanning-and-push-protection/working-with-push-protection-from-the-command-line#resolving-a-blocked-push
remote:     
remote:     
remote:       —— Discord Bot Token —————————————————————————————————
remote:        locations:
remote:          - commit: 830eaa78096434bd76cbabce8b108b502e55a586
remote:            path: bun-hono-api/node_modules/bun-types/docs/guides/ecosystem/discordjs.md:34
remote:     
remote:        (?) To push, remove secret from commit(s) or follow this URL to allow the secret.
remote:        https://github.com/imevanc/spring-boot-vs-bun-hono-benchmark/security/secret-scanning/unblock-secret/2yt4Ud0lGaVAhz4lYvEzL9ffCqX
remote:     
remote: 
remote: 
To https://github.com/imevanc/spring-boot-vs-bun-hono-benchmark.git
 ! [remote rejected] feat/add-load-tests -> feat/add-load-tests (push declined due to repository rule violations)
error: failed to push some refs to 'https://github.com/imevanc/spring-boot-vs-bun-hono-benchmark.git'
```


<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I included a test for the new code, or existing tests cover it
- [ ] I ran my tests locally and they pass (`bun-debug test test-file-name.test`)

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
- [ ] I wrote TypeScript/JavaScript tests and they pass locally (`bun-debug test test-file-name.test`)
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
